### PR TITLE
Update simplepypi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.2
+
+⬆ Bump simple-pypi to 1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pypi_simple",
+  "pypi_simple>=1.1.0",
   "packaging",
   "typer",
   "rich",

--- a/requirements/pyproject.txt
+++ b/requirements/pyproject.txt
@@ -37,7 +37,7 @@ pydantic==1.10.4
     # via pypi-simple
 pygments==2.14.0
     # via rich
-pypi-simple==1.0.0
+pypi-simple==1.1.0
     # via piplexed (pyproject.toml)
 requests==2.28.1
     # via


### PR DESCRIPTION
Simple pypi has updated version from 1.0.0 to 1.1.0.
This update includes an update to their API as results in an UnexpectedRepoVersionWarning when using.
Updating dependeny reolves this issue. 