### PR TITLE
Python 38 39

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-PYTHON_VERSIONS = ["3.11", "3.10"]
+PYTHON_VERSIONS = ["3.11", "3.10", "3.9", "3.8"]
 PYTHON_DEFAULT_VERSION = "3.11"
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,11 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
-  "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
   "pypi_simple>=1.1.0",

--- a/src/piplexed/_print_tree.py
+++ b/src/piplexed/_print_tree.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
 from typing import cast
 

--- a/src/piplexed/cli.py
+++ b/src/piplexed/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typer
 
 import piplexed

--- a/src/piplexed/pipx_venvs.py
+++ b/src/piplexed/pipx_venvs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 from dataclasses import dataclass

--- a/src/piplexed/pypi_info.py
+++ b/src/piplexed/pypi_info.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Generator
 from typing import TypedDict
 from typing import cast


### PR DESCRIPTION
Added python 3.8 and 3.9 to python version in nox.
Fixed failing tests which were due to typing syntax with `from __future__ import annotations`