### PR TITLE
🐛exclude non-pypi packages from pipx metadata

### DIFF
--- a/src/piplexed/pipx_venvs.py
+++ b/src/piplexed/pipx_venvs.py
@@ -29,10 +29,12 @@ def get_pipx_metadata(venv_dir: Path = PIPX_LOCAL_VENVS) -> list[PackageInfo]:
             if item.suffix == ".json":  # pragma: no branch
                 with open(item) as f:
                     data = json.load(f)
-                    pkg_data = PackageInfo(
-                        name=canonicalize_name(data["main_package"]["package"]),
-                        version=Version(data["main_package"]["package_version"]),
-                        python=data["python_version"].split()[-1],
-                    )
-                    venvs.append(pkg_data)
+                    # packages installed from pypi have the same package and package_or_url
+                    if data["main_package"]["package"] == data["main_package"]["package_or_url"]:
+                        pkg_data = PackageInfo(
+                            name=canonicalize_name(data["main_package"]["package"]),
+                            version=Version(data["main_package"]["package_version"]),
+                            python=data["python_version"].split()[-1],
+                        )
+                        venvs.append(pkg_data)
     return venvs

--- a/tests/test_pipx_venvs.py
+++ b/tests/test_pipx_venvs.py
@@ -3,7 +3,7 @@ from packaging.version import Version
 from piplexed.pipx_venvs import PackageInfo
 from piplexed.pipx_venvs import get_pipx_metadata
 
-TEST_PIPX_METADATA = """{
+TEST_PIPX_PYPI_METADATA = """{
     "injected_packages": {},
     "main_package": {
         "app_paths": [
@@ -30,12 +30,47 @@ TEST_PIPX_METADATA = """{
     "venv_args": []
 }"""
 
+TEST_PIPX_LOCAL_METADATA = """{
+    "injected_packages": {},
+    "main_package": {
+        "app_paths": [
+            {
+                "__Path__": "C:\\\\path\\\\to\\\\test.exe",
+                "__type__": "Path"
+            }
+        ],
+        "app_paths_of_dependencies": {},
+        "apps": [
+            "local.exe"
+        ],
+        "apps_of_dependencies": [],
+        "include_apps": true,
+        "include_dependencies": false,
+        "package": "Local_Package",
+        "package_or_url": "path/to/local/wheel",
+        "package_version": "23.1.0",
+        "pip_args": [],
+        "suffix": ""
+    },
+    "pipx_metadata_version": "0.3",
+    "python_version": "Python 3.11.2",
+    "venv_args": []
+}"""
+
 
 def test_get_pipx_metadata(tmp_path):
-    env_dir = tmp_path / "venv"
+    env_dir = tmp_path / "venvs"
     env_dir.mkdir()
-    test_json = env_dir / "test.json"
-    test_json.write_text(TEST_PIPX_METADATA)
-    assert get_pipx_metadata(tmp_path) == [
+    pypi_package = env_dir / "pypi_package"
+    pypi_package.mkdir()
+    pypi_test_json = pypi_package / "test.json"
+    pypi_test_json.write_text(TEST_PIPX_PYPI_METADATA)
+
+    local_package = env_dir / "local_package"
+    local_package.mkdir()
+    local_test_json = local_package / "test.json"
+    local_test_json.write_text(TEST_PIPX_LOCAL_METADATA)
+
+    assert get_pipx_metadata(env_dir) == [
         PackageInfo(name="testy-mctestface", version=Version("23.1.0"), python="3.11.2"),
     ]


### PR DESCRIPTION
Fixes #15 

Issue arises because a local package has been installed that is not on pypi, when `get_project_page()` gets called can't find the package on pypi so returns a NoSuchProjectError.
Two ways to fix this:
1. `try` `except` handling of exception
2. prevent non-pypi packages being requested by `get_project_page()`

Went with option 2, in the `pipx_metatdata.json` file there are 2 keys `package` and `package_or_url`. When a package is installed from PyPI these 2 are identical, where a package has been installed from local the `package_or_url` is the path to the package wheel.