### PR TITLE
Add cache path

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -5,6 +5,7 @@ PYTHON_DEFAULT_VERSION = "3.11"
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = (
     "tests",
+    "coverage_report",
     "lint",
 )
 
@@ -17,7 +18,15 @@ LINT_DEPENDENCIES = "requirements/linting.txt"
 def tests(session):
     session.run("python", "-m", "pip", "install", "-U", "pip")
     session.install(".", "-r", TEST_DEPENDENCIES)
-    session.run("pytest", "tests")
+    session.run("coverage", "run", "-m", "pytest", "tests")
+
+
+@nox.session()
+def coverage_report(session):
+    session.install("coverage[toml]")
+
+    session.run("coverage", "report", "--show-missing", "--fail-under=80")
+    session.run("coverage", "erase")
 
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ extend-immutable-calls = ["typer.Option"]
 "src/piplexed/cli.py" = ["FBT001", "A001"]  # typer uses booleans in CLI args
 
 [tool.coverage.run]
-parallel = true
 branch = true
 source = ["piplexed"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
   "packaging",
   "typer",
   "rich",
-  "requests-cache"
+  "requests-cache",
+  "platformdirs>=3.5"
 ]
 dynamic = ["version"]
 

--- a/requirements/pyproject.txt
+++ b/requirements/pyproject.txt
@@ -34,7 +34,9 @@ packaging==23.1
     #   piplexed (pyproject.toml)
     #   pypi-simple
 platformdirs==3.5.1
-    # via requests-cache
+    # via
+    #   piplexed (pyproject.toml)
+    #   requests-cache
 pydantic==1.10.8
     # via pypi-simple
 pygments==2.15.1

--- a/src/piplexed/pypi_info.py
+++ b/src/piplexed/pypi_info.py
@@ -8,7 +8,7 @@ from typing import cast
 from packaging.utils import NormalizedName
 from packaging.utils import canonicalize_name
 from packaging.version import Version
-from platformdirs import user_cache_dir
+from platformdirs import user_cache_path
 from pypi_simple import DistributionPackage
 from pypi_simple import PyPISimple
 from requests_cache import CachedSession
@@ -17,7 +17,7 @@ from piplexed.pipx_venvs import PackageInfo
 from piplexed.pipx_venvs import get_pipx_metadata
 from piplexed.version import VERSION
 
-DEFAULT_CACHE: Path = Path(user_cache_dir(appname="piplexed", version=VERSION)) / "pypi_cache.sqlite"
+DEFAULT_CACHE: Path = user_cache_path(appname="piplexed", version=VERSION) / "pypi_cache.sqlite"
 
 
 class PackageVersions(TypedDict):
@@ -60,7 +60,7 @@ def get_latest_version(packages: list[DistributionPackage], *, stable: bool) -> 
 def find_outdated_packages(cache_dir: Path = DEFAULT_CACHE, *, stable: bool = True) -> list[PackageVersions]:
     updates: list[PackageVersions] = []
     venvs = get_pipx_metadata()
-    session = CachedSession(cache_dir, backend="sqlite", expire_after=360)
+    session = CachedSession(str(cache_dir), backend="sqlite", expire_after=360)
     for pkg in venvs:
         for pypi_release in get_pypi_versions(session, pkg.name, stable=stable):
             if pypi_release.version > pkg.version:

--- a/src/piplexed/pypi_info.py
+++ b/src/piplexed/pypi_info.py
@@ -17,9 +17,7 @@ from piplexed.pipx_venvs import PackageInfo
 from piplexed.pipx_venvs import get_pipx_metadata
 from piplexed.version import VERSION
 
-DEFAULT_CACHE: Path = (
-    Path(user_cache_dir(appname="piplexed", appauthor="ajwhite", version=VERSION)) / "pypi_cache.sqlite"
-)
+DEFAULT_CACHE: Path = Path(user_cache_dir(appname="piplexed", version=VERSION)) / "pypi_cache.sqlite"
 
 
 class PackageVersions(TypedDict):

--- a/src/piplexed/version.py
+++ b/src/piplexed/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.1"
+VERSION = "0.0.2"

--- a/tests/test_pypi_info.py
+++ b/tests/test_pypi_info.py
@@ -8,9 +8,10 @@ from pypi_simple import DistributionPackage
 from pypi_simple import ProjectPage
 
 from piplexed.pipx_venvs import PackageInfo
-from piplexed.pypi_info import PackageVersions, get_latest_version
-from piplexed.pypi_info import get_pypi_versions
+from piplexed.pypi_info import PackageVersions
 from piplexed.pypi_info import find_outdated_packages
+from piplexed.pypi_info import get_latest_version
+from piplexed.pypi_info import get_pypi_versions
 
 
 @pytest.mark.parametrize(
@@ -198,7 +199,7 @@ def test_find_outdated_packages(mock_pypi, mock_pipx_metadata, tmp_path):
     ]
 
     assert find_outdated_packages(tmp_path, stable=True) == [
-        PackageVersions(package=canonicalize_name("package_1"), pipx=Version("1.0.0"), pypi=Version("2.0.0"))
+        PackageVersions(package=canonicalize_name("package_1"), pipx=Version("1.0.0"), pypi=Version("2.0.0")),
     ]
 
 
@@ -216,5 +217,5 @@ def test_find_outdated_packages_pre(mock_pypi, mock_pipx_metadata, tmp_path):
     ]
 
     assert find_outdated_packages(tmp_path, stable=False) == [
-        PackageVersions(package=canonicalize_name("package_1"), pipx=Version("1.0.0"), pypi=Version("2.1b0"))
+        PackageVersions(package=canonicalize_name("package_1"), pipx=Version("1.0.0"), pypi=Version("2.1b0")),
     ]


### PR DESCRIPTION
Fixes #16 

- added a cache directory using `platformdirs` for os interoperability
- added tests for `find_outdated_packages()`
- added coverage to nox and set a fail limit (80%)