### PR TITLE
🩹 fix requests deprecation warning

### DIFF
--- a/src/piplexed/pypi_info.py
+++ b/src/piplexed/pypi_info.py
@@ -67,5 +67,5 @@ def find_outdated_packages(cache_dir: Path = DEFAULT_CACHE, *, stable: bool = Tr
                 updates.append({"package": pkg.name, "pipx": pkg.version, "pypi": pypi_release.version})
                 break
 
-    session.remove_expired_responses()
+    session.cache.delete(expired=True)
     return updates


### PR DESCRIPTION
Fixes #18 
Requests cache is deprecating `remove_expired_responses()` in favour of more granular methods.
Replacing with `BaseCache.cache.delete()` method to suppress warning and prevent failure when removed entirely.