### PR TITLE
Fix pypi repo link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [0.1.0](https://github.com/aj-white/piplexed/tree/0.1.0) - 2023-06-12
+## [0.1.1](https://github.com/aj-white/piplexed/compare/v0.1.0...v0.1.1) - 2023-06-15
+
+### Fixed
+
+- Erroneous github repo link in `pyproject.toml`
+
+## [0.1.0](https://github.com/aj-white/piplexed/tag/v0.1.0) - 2023-06-12
 
 ### Fixed
 

--- a/docs/Release-notes.md
+++ b/docs/Release-notes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 0.1.1
+
+### Fixed
+
+- Github repo link in `pyproject.toml` was wrong so links on PyPI returned a **404** error.
+
+
 ## 0.1.0
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ piplexed = "piplexed.cli:app"
 
 [project.urls]
 Documentation = "https://aj-white.github.io/piplexed/"
-Issues = "https://github.com/unknown/piplexed/issues"
-Source = "https://github.com/unknown/piplexed"
+Issues = "https://github.com/aj-white/piplexed/issues"
+Source = "https://github.com/aj-white/piplexed"
 
 [tool.hatch.version]
 path = "src/piplexed/version.py"

--- a/src/piplexed/version.py
+++ b/src/piplexed/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.0"
+VERSION = "0.1.1"


### PR DESCRIPTION
Fixes #22 
For some reason username in `pyproject.toml` project links was set to *unknown*.