### PR TITLE
Py 312 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-        allow-preleases: true
+        allow-prereleases: true
         
     - name: Upgrade pip and install nox
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     
     steps:
     - uses: actions/checkout@v3
@@ -39,6 +39,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-preleases: true
+        
     - name: Upgrade pip and install nox
       run: |
         python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased](https://github.com/aj-white/piplexed/compare/v0.1.2...HEAD)
+
+- Added support for python 3.12
+
+
 ## [0.1.2](https://github.com/aj-white/piplexed/compare/v0.1.1...v0.1.2) - 2023-06-16
 
 ### Fixed

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-PYTHON_VERSIONS = ["3.11", "3.10", "3.9", "3.8"]
+PYTHON_VERSIONS = ["3.12", "3.11", "3.10", "3.9", "3.8"]
 PYTHON_DEFAULT_VERSION = "3.11"
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = (

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -30,7 +30,7 @@ pygments==2.15.1
     # via
     #   -c requirements\pyproject.txt
     #   rich
-pytest==7.3.1
+pytest==7.3.2
     # via
     #   -r requirements/tests.in
     #   pytest-pretty


### PR DESCRIPTION
Adds python 3.12 to CI and noxfile to run tests against latest version.
All tests pass, neede to bump pytest version which also includes 3.12 support.