### PR TITLE
Chore switch to ruff fmt

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -33,8 +33,8 @@ def coverage_report(session):
 def lint(session):
     session.run("python", "-m", "pip", "install", "-U", "pip")
     session.install(".", "-r", LINT_DEPENDENCIES)
-    session.run("black", "src", "--check")
-    session.run("ruff", ".")
+    session.run("ruff", "format", "src", "--check")
+    session.run("ruff", "check", ".")
     session.run("mypy", "src")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ line-length = 120
 [tool.ruff]
 target-version = "py311"
 line-length = 120
+
+[tool.ruff.lint]
 select = [
   "A",
   "ARG",
@@ -80,23 +82,28 @@ ignore = [
   "FBT003",
   # Ignore checks for possible passwords and asserts
   "S101", "S105", "S106", "S107",
-  # Ignore complexity
-  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
+  # Ignore complexity and formatting conflicts
+  "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915", "COM812", "ISC001"
 ]
 unfixable = [
   # Don't touch unused imports
   "F401",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-single-line = true
 known-first-party = ["piplexed"]
 
-[tool.ruff.flake8-bugbear]
+[tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["typer.Option"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "src/piplexed/cli.py" = ["FBT001", "A001"]  # typer uses booleans in CLI args
+
+[tool.ruff.format]
+quote-style = "double"
+skip-magic-trailing-comma = false
+docstring-code-format = false
 
 [tool.coverage.run]
 branch = true

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,11 +4,13 @@
 #
 #    pip-compile requirements/docs.in
 #
-certifi==2023.7.22
+babel==2.16.0
+    # via mkdocs-material
+certifi==2024.7.4
     # via
     #   -c requirements\pyproject.txt
     #   requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via
     #   -c requirements\pyproject.txt
     #   requests
@@ -24,53 +26,68 @@ colorama==0.4.6
     #   mkdocs-material
 ghp-import==2.1.0
     # via mkdocs
-idna==3.4
+idna==3.8
     # via
     #   -c requirements\pyproject.txt
     #   requests
-jinja2==3.1.2
+jinja2==3.1.4
     # via
     #   mkdocs
     #   mkdocs-material
-markdown==3.3.7
+markdown==3.7
     # via
     #   mkdocs
     #   mkdocs-material
     #   pymdown-extensions
-markupsafe==2.1.2
-    # via jinja2
+markupsafe==2.1.5
+    # via
+    #   jinja2
+    #   mkdocs
 mergedeep==1.3.4
-    # via mkdocs
-mkdocs==1.4.3
+    # via
+    #   mkdocs
+    #   mkdocs-get-deps
+mkdocs==1.6.0
     # via
     #   -r requirements/docs.in
     #   mkdocs-material
-mkdocs-material==9.1.15
+mkdocs-get-deps==0.2.0
+    # via mkdocs
+mkdocs-material==9.5.33
     # via -r requirements/docs.in
-mkdocs-material-extensions==1.1.1
+mkdocs-material-extensions==1.3.1
     # via mkdocs-material
-packaging==23.2
+packaging==24.1
     # via
     #   -c requirements\pyproject.txt
     #   mkdocs
-pygments==2.16.1
+paginate==0.5.7
+    # via mkdocs-material
+pathspec==0.12.1
+    # via mkdocs
+platformdirs==4.2.2
+    # via
+    #   -c requirements\pyproject.txt
+    #   mkdocs-get-deps
+pygments==2.18.0
     # via
     #   -c requirements\pyproject.txt
     #   mkdocs-material
-pymdown-extensions==10.0.1
+pymdown-extensions==10.9
     # via mkdocs-material
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via ghp-import
-pyyaml==6.0
+pyyaml==6.0.2
     # via
     #   mkdocs
+    #   mkdocs-get-deps
     #   pymdown-extensions
     #   pyyaml-env-tag
 pyyaml-env-tag==0.1
     # via mkdocs
-regex==2023.5.5
+regex==2024.7.24
     # via mkdocs-material
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c requirements\pyproject.txt
     #   mkdocs-material
@@ -78,9 +95,9 @@ six==1.16.0
     # via
     #   -c requirements\pyproject.txt
     #   python-dateutil
-urllib3==2.0.6
+urllib3==2.2.2
     # via
     #   -c requirements\pyproject.txt
     #   requests
-watchdog==3.0.0
+watchdog==5.0.0
     # via mkdocs

--- a/requirements/linting.in
+++ b/requirements/linting.in
@@ -1,3 +1,2 @@
-black
 ruff
 mypy

--- a/requirements/linting.txt
+++ b/requirements/linting.txt
@@ -4,25 +4,11 @@
 #
 #    pip-compile requirements/linting.in
 #
-black==23.9.1
-    # via -r requirements/linting.in
-click==8.1.7
-    # via black
-colorama==0.4.6
-    # via click
-mypy==1.5.1
+mypy==1.11.2
     # via -r requirements/linting.in
 mypy-extensions==1.0.0
-    # via
-    #   black
-    #   mypy
-packaging==23.2
-    # via black
-pathspec==0.11.2
-    # via black
-platformdirs==3.11.0
-    # via black
-ruff==0.0.292
+    # via mypy
+ruff==0.6.2
     # via -r requirements/linting.in
-typing-extensions==4.8.0
+typing-extensions==4.12.2
     # via mypy

--- a/requirements/pyproject.txt
+++ b/requirements/pyproject.txt
@@ -4,26 +4,26 @@
 #
 #    pip-compile --output-file=requirements/pyproject.txt pyproject.toml
 #
-annotated-types==0.6.0
+annotated-types==0.7.0
     # via pydantic
-attrs==23.1.0
+attrs==24.2.0
     # via
     #   cattrs
     #   mailbits
     #   requests-cache
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via pypi-simple
-cattrs==23.1.2
+cattrs==23.2.3
     # via requests-cache
-certifi==2023.7.22
+certifi==2024.7.4
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via typer
 colorama==0.4.6
     # via click
-idna==3.4
+idna==3.8
     # via requests
 mailbits==0.2.1
     # via pypi-simple
@@ -31,44 +31,48 @@ markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-packaging==23.2
+packaging==24.1
     # via
     #   piplexed (pyproject.toml)
     #   pypi-simple
-platformdirs==3.11.0
+platformdirs==4.2.2
     # via
     #   piplexed (pyproject.toml)
     #   requests-cache
-pydantic==2.4.2
+pydantic==2.8.2
     # via pypi-simple
-pydantic-core==2.10.1
+pydantic-core==2.20.1
     # via pydantic
-pygments==2.16.1
+pygments==2.18.0
     # via rich
-pypi-simple==1.2.0
+pypi-simple==1.6.0
     # via piplexed (pyproject.toml)
-requests==2.31.0
+requests==2.32.3
     # via
     #   pypi-simple
     #   requests-cache
-requests-cache==1.1.0
+requests-cache==1.2.1
     # via piplexed (pyproject.toml)
-rich==13.6.0
-    # via piplexed (pyproject.toml)
+rich==13.8.0
+    # via
+    #   piplexed (pyproject.toml)
+    #   typer
+shellingham==1.5.4
+    # via typer
 six==1.16.0
     # via url-normalize
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
-typer==0.9.0
+typer==0.12.5
     # via piplexed (pyproject.toml)
-typing-extensions==4.8.0
+typing-extensions==4.12.2
     # via
     #   pydantic
     #   pydantic-core
     #   typer
 url-normalize==1.4.3
     # via requests-cache
-urllib3==2.0.6
+urllib3==2.2.2
     # via
     #   requests
     #   requests-cache

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -8,7 +8,7 @@ colorama==0.4.6
     # via
     #   -c requirements\pyproject.txt
     #   pytest
-coverage[toml]==7.3.2
+coverage[toml]==7.6.1
     # via -r requirements/tests.in
 iniconfig==2.0.0
     # via pytest
@@ -20,23 +20,23 @@ mdurl==0.1.2
     # via
     #   -c requirements\pyproject.txt
     #   markdown-it-py
-packaging==23.2
+packaging==24.1
     # via
     #   -c requirements\pyproject.txt
     #   pytest
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-pygments==2.16.1
+pygments==2.18.0
     # via
     #   -c requirements\pyproject.txt
     #   rich
-pytest==7.4.2
+pytest==8.3.2
     # via
     #   -r requirements/tests.in
     #   pytest-pretty
 pytest-pretty==1.2.0
     # via -r requirements/tests.in
-rich==13.6.0
+rich==13.8.0
     # via
     #   -c requirements\pyproject.txt
     #   pytest-pretty


### PR DESCRIPTION
Ruff has a formatter which is essentially black compatible, removed black as formatter and configured for ruff. Faster and saves a dependancy install in CI.