### PR TITLE
Performance increased and progress bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased](https://github.com/aj-white/piplexed/compare/v0.5.0...HEAD)
 
+## Added
+
+- Performance improvement, refactored to multi-threaded design.
+- Progress bar when getting data from pypi
+
+## Changed
+- Updated tests and added explanitory docstrings
+
 ## [0.5.0](https://github.com/aj-white/piplexed/compare/v0.4.0...v0.5.0)
 
 ### Added

--- a/src/piplexed/_print_table.py
+++ b/src/piplexed/_print_table.py
@@ -7,7 +7,6 @@ from rich.table import Table
 from rich.text import Text
 
 from piplexed.pipx_venvs import PackageInfo
-from piplexed.pypi_info import PackageVersions
 
 
 def print_list_table(packages: Iterable[PackageInfo]) -> None:
@@ -22,17 +21,17 @@ def print_list_table(packages: Iterable[PackageInfo]) -> None:
     rich_print(table)
 
 
-def print_outdated_table(package_data: Iterable[PackageVersions]) -> None:
+def print_outdated_table(package_data: Iterable[PackageInfo]) -> None:
     table = Table(title="Pip❌ Outdated Packages")
     table.add_column("Package Name", justify="right", style="dark_orange", no_wrap=True)
     table.add_column("Pipx Version", justify="right", style="deep_sky_blue1", no_wrap=True)
     table.add_column("PyPI Version", justify="right", style="red3", no_wrap=True)
 
     for pkg in package_data:
-        pypi_info = Text(f"{pkg['pypi']}", "green1")
-        if pkg["pypi"].is_prerelease or pkg["pypi"].is_devrelease:
+        pypi_info = Text(f"{pkg.latest_pypi_version}", "green1")
+        if pkg.latest_pypi_version is not None and pkg.latest_pypi_version.is_prerelease:
             pypi_info.append(" ⚠", "bright_yellow")
 
-        table.add_row(pkg["package"], f"{pkg['pipx']}", pypi_info)
+        table.add_row(pkg.name, f"{pkg.version}", pypi_info)
 
     rich_print(table)

--- a/src/piplexed/_print_tree.py
+++ b/src/piplexed/_print_tree.py
@@ -8,7 +8,6 @@ from rich.text import Text
 from rich.tree import Tree
 
 from piplexed.pipx_venvs import PackageInfo
-from piplexed.pypi_info import PackageVersions
 
 
 def print_list_tree(packages: Iterable[PackageInfo]) -> None:
@@ -27,17 +26,17 @@ def print_list_tree(packages: Iterable[PackageInfo]) -> None:
     rich_print(tree)
 
 
-def print_list_outdated(package_data: Iterable[PackageVersions]) -> None:
+def print_list_outdated(package_data: Iterable[PackageInfo]) -> None:
     tree = Tree("Pip❌ Outdated Packages", guide_style="cyan")
     for pkg in package_data:
         pkg_name = Text(
-            pkg["package"].title(),
+            pkg.name.title(),
             "bright_yellow bold",
         )
 
-        pipx_info = Text("pipx version - ", "white").append(f"{pkg['pipx']}", "red3")
-        pypi_info = Text("PyPI version - ", "white").append(f"{pkg['pypi']}", "green1")
-        if pkg["pypi"].is_prerelease or pkg["pypi"].is_devrelease:
+        pipx_info = Text("pipx version - ", "white").append(f"{pkg.version}", "red3")
+        pypi_info = Text("PyPI version - ", "white").append(f"{pkg.latest_pypi_version}", "green1")
+        if pkg.latest_pypi_version is not None and pkg.latest_pypi_version.is_prerelease:
             pypi_info.append(" ⚠", "bright_yellow")
 
         pkg_branch = tree.add(pkg_name)

--- a/src/piplexed/pipx_venvs.py
+++ b/src/piplexed/pipx_venvs.py
@@ -52,6 +52,13 @@ class PackageInfo:
     name: NormalizedName
     version: Version
     python: str | None = None
+    latest_pypi_version: Version | None = None
+
+    def newer_pypi_version(self) -> bool:
+        if self.latest_pypi_version is not None:
+            return self.latest_pypi_version > self.version
+        else:
+            return False
 
 
 def is_metadata_version_valid(metadata_version: str, pipx_metadata_vsn: list[str] = PIPX_METADATA_VERSIONS) -> bool:
@@ -84,4 +91,5 @@ def get_pipx_metadata(venv_dir: Path | None = PIPX_LOCAL_VENVS) -> list[PackageI
                             python=data["python_version"].split()[-1],
                         )
                         venvs.append(pkg_data)
+
     return venvs

--- a/src/piplexed/pypi_info.py
+++ b/src/piplexed/pypi_info.py
@@ -74,7 +74,7 @@ def find_outdated_packages(cache_dir: Path = DEFAULT_CACHE, *, stable: bool = Tr
         stack.enter_context(progress_bar)
         task = progress_bar.add_task("[red]Getting PyPI version data", total=len(venvs))
 
-        executor = stack.enter_context(ThreadPoolExecutor(max_workers=4))
+        executor = stack.enter_context(ThreadPoolExecutor(max_workers=5))
 
         results = [executor.submit(get_pypi_versions, client, pkg, stable) for pkg in venvs]
 

--- a/tests/test_pipx_venvs.py
+++ b/tests/test_pipx_venvs.py
@@ -272,3 +272,18 @@ def test_pipx_metadata_warning(venv_dir_test_setup):
 
     with pytest.warns(UserWarning):
         get_pipx_metadata(venv_dir_test_setup)
+
+
+def test_newer_pypi_version():
+    package = PackageInfo("package1", "1.0.0", None, "1.1.0")
+    assert package.newer_pypi_version()
+
+
+def test_pypi_version_no_change():
+    package = PackageInfo("package1", "1.0.0", None, "1.0.0")
+    assert not package.newer_pypi_version()
+
+
+def test_pypi_version_no_value():
+    package = PackageInfo("package1", "1.0.0", None, None)
+    assert not package.newer_pypi_version()

--- a/tests/test_print_table.py
+++ b/tests/test_print_table.py
@@ -16,10 +16,13 @@ def test_print_table(capsys: CaptureFixture[str]):
     out, err = capsys.readouterr()
     assert not err
     output = [s.strip() for s in out.splitlines()]
+    headers = (
+        "Package Name",
+        "Pipx Version",
+        "Python Version",
+    )
     assert output[0].startswith("Pip❎ Packages")
-    assert output[1] == "┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓"
-    assert output[2] == "┃ Package Name ┃ Pipx Version ┃ Python Version ┃"
-    assert output[3] == "┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩"
+    assert all(header in output[2] for header in headers)
     assert output[4] == "│            A │        1.0.1 │         3.11.3 │"
     assert output[5] == "│            B │        2.2.1 │         3.11.3 │"
     assert output[6] == "└──────────────┴──────────────┴────────────────┘"
@@ -27,8 +30,8 @@ def test_print_table(capsys: CaptureFixture[str]):
 
 def test_print_list_outdated(capsys: CaptureFixture[str]):
     packages = [
-        {"package": "B", "pipx": Version("1.5.0"), "pypi": Version("1.6.0")},
-        {"package": "C", "pipx": Version("2.6.0"), "pypi": Version("3.0a0")},
+        PackageInfo("B", Version("1.5.0"), python="3.11.3", latest_pypi_version=Version("1.6.0")),
+        PackageInfo("C", Version("2.6.0"), python="3.11.3", latest_pypi_version=Version("3.0a.0")),
     ]
 
     print_outdated_table(packages)
@@ -36,10 +39,14 @@ def test_print_list_outdated(capsys: CaptureFixture[str]):
     out, err = capsys.readouterr()
     assert not err
     output = [s.strip() for s in out.splitlines()]
+    headers = (
+        "Package Name",
+        "Pipx Version",
+        "PyPI Version",
+    )
+
     assert output[0] == "Pip❌ Outdated Packages"
-    assert output[1] == "┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓"
-    assert output[2] == "┃ Package Name ┃ Pipx Version ┃ PyPI Version ┃"
-    assert output[3] == "┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩"
+    assert all(header in output[2] for header in headers)
     assert output[4] == "│            B │        1.5.0 │        1.6.0 │"
     assert output[5] == "│            C │        2.6.0 │      3.0a0 ⚠ │"
     assert output[6] == "└──────────────┴──────────────┴──────────────┘"

--- a/tests/test_print_tree.py
+++ b/tests/test_print_tree.py
@@ -24,8 +24,8 @@ def test_print_list(capsys: CaptureFixture[str]):
 
 def test_print_list_outdated(capsys: CaptureFixture[str]):
     packages = [
-        {"package": "B", "pipx": Version("1.5.0"), "pypi": Version("1.6.0")},
-        {"package": "C", "pipx": Version("2.6.0"), "pypi": Version("3.0a0")},
+        PackageInfo("B", Version("1.5.0"), python="3.11.3", latest_pypi_version=Version("1.6.0")),
+        PackageInfo("C", Version("2.6.0"), python="3.11.3", latest_pypi_version=Version("3.0a.0")),
     ]
 
     print_list_outdated(packages)

--- a/tests/test_pypi_info.py
+++ b/tests/test_pypi_info.py
@@ -2,16 +2,14 @@ from unittest.mock import create_autospec
 from unittest.mock import patch
 
 import pytest
-from packaging.utils import canonicalize_name
 from packaging.version import Version
 from pypi_simple import DistributionPackage
-from pypi_simple import ProjectPage
+from pypi_simple.client import PyPISimple
 
 from piplexed.pipx_venvs import PackageInfo
-from piplexed.pypi_info import PackageVersions
 from piplexed.pypi_info import find_outdated_packages
-from piplexed.pypi_info import get_latest_version
 from piplexed.pypi_info import get_pypi_versions
+from piplexed.pypi_info import latest_pypi_version
 
 
 @pytest.mark.parametrize(
@@ -41,7 +39,7 @@ def test_get_latest_version_stable_flag(packages_data, non_pre_release, expected
     packages = [
         create_autospec(DistributionPackage, version=v, package_type=t, is_yanked=y) for v, t, y in packages_data
     ]
-    assert get_latest_version(packages, stable=non_pre_release) == expected
+    assert latest_pypi_version(packages, stable=non_pre_release) == expected
 
 
 @pytest.mark.parametrize(
@@ -97,13 +95,25 @@ def test_get_latest_version_stable_flag(packages_data, non_pre_release, expected
             Version("1.0.0"),
             id="pre_release and yanked sdists",
         ),
+        pytest.param(
+            [
+                ("1.0.0", "sdist", False),
+                ("invalid", "sdist", False),
+            ],
+            True,
+            Version("1.0.0"),
+            id="Invalid version does not fail",
+        ),
     ],
 )
 def test_get_latest_version_sdists(packages_data, non_pre_release, expected):
+    """
+    Test examples are all sdists as piplexed only finds versions for sdists
+    """
     packages = [
         create_autospec(DistributionPackage, version=v, package_type=t, is_yanked=y) for v, t, y in packages_data
     ]
-    assert get_latest_version(packages, stable=non_pre_release) == expected
+    assert latest_pypi_version(packages, stable=non_pre_release) == expected
 
 
 @pytest.mark.parametrize(
@@ -162,60 +172,116 @@ def test_get_latest_version_sdists(packages_data, non_pre_release, expected):
     ],
 )
 def test_get_latest_version_wheels(packages_data, non_pre_release, expected):
+    """
+    Piplexed only finds versions for sdists, this test, this test ensures wheels
+    aren't included.
+    """
     packages = [
         create_autospec(DistributionPackage, version=v, package_type=t, is_yanked=y) for v, t, y in packages_data
     ]
-    assert get_latest_version(packages, stable=non_pre_release) == expected
+    assert latest_pypi_version(packages, stable=non_pre_release) == expected
 
 
-@patch("piplexed.pypi_info.PyPISimple.get_project_page")
+@patch("piplexed.pypi_info.pypi_package_info")
 def test_get_pypi_versions(mock_page):
-    packages_data = [
+    pypi_packages_data = [
         ("1.0.0", "sdist", False),
         ("2.0.0", "sdist", False),
         ("2.5.0", "sdist", False),
     ]
-    packages = [
-        create_autospec(DistributionPackage, version=v, package_type=t, is_yanked=y) for v, t, y in packages_data
+    pypi_packages = [
+        create_autospec(DistributionPackage, version=v, package_type=t, is_yanked=y) for v, t, y in pypi_packages_data
     ]
 
-    page = create_autospec(ProjectPage, project="testproj", packages=packages)
-    mock_page.return_value = page
+    mock_page.return_value = pypi_packages
 
-    result = get_pypi_versions(session=None, package_name="testproj", stable=True)
-    assert list(result) == [PackageInfo(name="testproj", version=Version("2.5.0"), python=None)]
+    mock_client = create_autospec(PyPISimple, spec_set=True)
+    package = PackageInfo(name="testproj", version=Version("0.5.0"), python=None, latest_pypi_version=None)
 
-
-@patch("piplexed.pypi_info.get_pipx_metadata")
-@patch("piplexed.pypi_info.get_pypi_versions")
-def test_find_outdated_packages(mock_pypi, mock_pipx_metadata, tmp_path):
-    mock_pipx_metadata.return_value = [
-        PackageInfo(name=canonicalize_name("package_1"), version=Version("1.0.0")),
-    ]
-
-    mock_pypi.return_value = [
-        PackageInfo(name=canonicalize_name("package_1"), version=Version("2.0.0")),
-        PackageInfo(name=canonicalize_name("package_1"), version=Version("1.0.0")),
-    ]
-
-    assert find_outdated_packages(tmp_path, stable=True) == [
-        PackageVersions(package=canonicalize_name("package_1"), pipx=Version("1.0.0"), pypi=Version("2.0.0")),
+    result = get_pypi_versions(client=mock_client, package=package, stable=True)
+    assert [result] == [
+        PackageInfo(name="testproj", version=Version("0.5.0"), python=None, latest_pypi_version=Version("2.5.0"))
     ]
 
 
-@patch("piplexed.pypi_info.get_pipx_metadata")
-@patch("piplexed.pypi_info.get_pypi_versions")
-def test_find_outdated_packages_pre(mock_pypi, mock_pipx_metadata, tmp_path):
-    mock_pipx_metadata.return_value = [
-        PackageInfo(name=canonicalize_name("package_1"), version=Version("1.0.0")),
-    ]
+# -----------------------------------------------------
+# To test find_outdated_packages need to mock some data
 
-    mock_pypi.return_value = [
-        PackageInfo(name=canonicalize_name("package_1"), version=Version("2.1b0")),
-        PackageInfo(name=canonicalize_name("package_1"), version=Version("2.0.0")),
-        PackageInfo(name=canonicalize_name("package_1"), version=Version("1.0.0")),
-    ]
 
-    assert find_outdated_packages(tmp_path, stable=False) == [
-        PackageVersions(package=canonicalize_name("package_1"), pipx=Version("1.0.0"), pypi=Version("2.1b0")),
-    ]
+@pytest.fixture
+def mock_get_pipx_metadata():
+    with patch("piplexed.pypi_info.get_pipx_metadata") as mock:
+        mock.return_value = [
+            PackageInfo(name="package1", version="1.0.0"),
+            PackageInfo(name="package2", version="2.0.0"),
+        ]
+        yield mock
+
+
+@pytest.fixture
+def mock_get_pypi_versions():
+    """
+    In find_outdated_packages get_pypi_version is called for each package
+    returned from get_pipx_metadata. Use side effects to get different results
+    for each package.
+    """
+    with patch("piplexed.pypi_info.get_pypi_versions") as mock:
+
+        def side_effect(client, pkg, stable):  # noqa: ARG001
+            if pkg.name == "package1":
+                return PackageInfo(
+                    name="package1", version="1.0.0", latest_pypi_version="1.1.0" if stable else "1.2.0-beta"
+                )
+            else:
+                return PackageInfo(name="package2", version="2.0.0", latest_pypi_version="2.0.0")
+
+        mock.side_effect = side_effect
+        yield mock
+
+
+def test_find_outdated_packages(tmp_path, mock_get_pipx_metadata, mock_get_pypi_versions):
+    result = find_outdated_packages(cache_dir=tmp_path / "cache")
+    assert len(result) == 1
+    assert result[0].name == "package1"
+    assert result[0].version == "1.0.0"
+    assert result[0].latest_pypi_version == "1.1.0"
+
+    mock_get_pipx_metadata.assert_called_once()
+    assert mock_get_pypi_versions.call_count == 2
+
+
+def test_find_outdated_packages_unstable(tmp_path, mock_get_pipx_metadata, mock_get_pypi_versions):
+    result = find_outdated_packages(cache_dir=tmp_path / "cache", stable=False)
+    assert len(result) == 1
+    assert result[0].name == "package1"
+    assert result[0].version == "1.0.0"
+    assert result[0].latest_pypi_version == "1.2.0-beta"
+
+    mock_get_pipx_metadata.assert_called_once()
+    assert mock_get_pypi_versions.call_count == 2
+
+
+def test_find_outdated_packages_no_updates(tmp_path, mock_get_pipx_metadata, mock_get_pypi_versions):
+    mock_get_pypi_versions.side_effect = lambda client, pkg, stable: (  # noqa: ARG005
+        PackageInfo(name="package1", version="1.0.0", latest_pypi_version="1.0.0" if not stable else "1.0.0")
+        if pkg.name == "package1"
+        else PackageInfo(name="package2", version="2.0.0", latest_pypi_version="2.0.0")
+    )
+
+    result = find_outdated_packages(cache_dir=tmp_path / "cache")
+    assert not result
+    mock_get_pipx_metadata.assert_called_once()
+    assert mock_get_pypi_versions.call_count == 2
+
+
+def test_find_outdated_packages_unstable_no_updates(tmp_path, mock_get_pipx_metadata, mock_get_pypi_versions):
+    mock_get_pypi_versions.side_effect = lambda client, pkg, stable: (  # noqa: ARG005
+        PackageInfo(name="package1", version="1.0.0", latest_pypi_version="1.0.0" if not stable else "1.0.0")
+        if pkg.name == "package1"
+        else PackageInfo(name="package2", version="2.0.0", latest_pypi_version="2.0.0")
+    )
+
+    result = find_outdated_packages(cache_dir=tmp_path / "cache", stable=False)
+    assert not result
+    mock_get_pipx_metadata.assert_called_once()
+    assert mock_get_pypi_versions.call_count == 2


### PR DESCRIPTION
Refactored design to be multi-threaded when making calls to pypi via pypi-simple client. Rough testing takes original performance of 4 - 7 seconds (with and without cache) to a slightly faster and more consistent 2.9 - 3.5 seconds, which is a 1.5 - 2x improvement. Also added a rich progress bar when fetching pypi data.
Updated tests for new design and added a few extra to increase coverage.