### PR TITLE
55 remove python38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     
     steps:
     - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -121,7 +121,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/
@@ -137,6 +137,9 @@ venv.bak/
 
 # mkdocs documentation
 /site
+
+# ruff
+.ruff_cache
 
 # mypy
 .mypy_cache/
@@ -164,4 +167,4 @@ cython_debug/
 #.idea/
 
 # VS Code
-.vscode/*
+.vscode*

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,6 @@
 import nox
 
-PYTHON_VERSIONS = ["3.12", "3.11", "3.10", "3.9", "3.8"]
+PYTHON_VERSIONS = ["3.12", "3.11", "3.10", "3.9"]
 PYTHON_DEFAULT_VERSION = "3.11"
 nox.options.reuse_existing_virtualenvs = True
 nox.options.sessions = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "piplexed"
 description = 'Find outdated python packages installed with pipx'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = ["pipx", "cli", " dependency"]
 authors = [
@@ -15,7 +15,6 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/tests/test_pipx_venvs.py
+++ b/tests/test_pipx_venvs.py
@@ -25,7 +25,7 @@ MOCK_BASE_PIPX_METADATA: dict[str, Any] = {
     "pipx_metadata_version": "0.1",
 }
 
-MOCK_PIPX_METADATA_0_4: dict[str, Any] = dict(MOCK_BASE_PIPX_METADATA, **{"source_interpreter": None})
+MOCK_PIPX_METADATA_0_4: dict[str, Any] = MOCK_BASE_PIPX_METADATA | {"source_interpreter": None}
 
 MOCK_PACKAGE_DATA_0_1: dict[str, Any] = {
     "package": None,
@@ -40,19 +40,16 @@ MOCK_PACKAGE_DATA_0_1: dict[str, Any] = {
     "package_version": "",
 }
 # would like to use | operator e.g. # MOCK_PACKAGE_DATA_0_1 | {"suffix": ""} but not supported in python 3.8
-MOCK_PACKAGE_DATA_0_2 = dict(MOCK_PACKAGE_DATA_0_1, **{"suffix": ""})
+MOCK_PACKAGE_DATA_0_2 = MOCK_PACKAGE_DATA_0_1 | {"suffix": ""}
 
-MOCK_PACKAGE_DATA_0_3_and_0_4 = dict(
-    MOCK_PACKAGE_DATA_0_2,
-    **{
-        "man_pages": [],
-        "man_paths": [],
-        "man_pages_of_dependencies": [],
-        "man_paths_of_dependencies": {},
-    },
-)
+MOCK_PACKAGE_DATA_0_3_and_0_4 = MOCK_PACKAGE_DATA_0_2 | {
+    "man_pages": [],
+    "man_paths": [],
+    "man_pages_of_dependencies": [],
+    "man_paths_of_dependencies": {},
+}
 
-MOCK_PACKAGE_DATA_0_5 = dict(MOCK_PACKAGE_DATA_0_3_and_0_4, **{"pinned": False})
+MOCK_PACKAGE_DATA_0_5 = MOCK_PACKAGE_DATA_0_3_and_0_4 | {"pinned": False}
 
 
 def mock_metadata(metadata_version: str, pypi_package: bool = True) -> dict[str, Any]:  # noqa: FBT001, FBT002


### PR DESCRIPTION
Closes #55.
Removes python 3.8 from classifiers and testing matrix in nox and CI.
Updates syntax to use | for dictionary merges.