### PR TITLE
Use uv nox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/aj-white/piplexed/compare/v0.6.0...HEAD)
 
+- Use `uv` with nox
+
 
 ## [0.6.0](https://github.com/aj-white/piplexed/compare/v0.5.0...v0.6.0)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,10 @@ import nox
 
 PYTHON_VERSIONS = ["3.13", "3.12", "3.11", "3.10", "3.9"]
 PYTHON_DEFAULT_VERSION = "3.12"
-nox.options.reuse_existing_virtualenvs = True
+
+nox.needs_version = ">=2024.3.2"
+nox.options.default_venv_backend = "uv|virtualenv"
+
 nox.options.sessions = (
     "tests",
     "coverage_report",
@@ -16,7 +19,6 @@ LINT_DEPENDENCIES = "requirements/linting.txt"
 
 @nox.session(python=PYTHON_VERSIONS)
 def tests(session):
-    session.run("python", "-m", "pip", "install", "-U", "pip")
     session.install(".", "-r", TEST_DEPENDENCIES)
     session.run("coverage", "run", "-m", "pytest", "tests")
 
@@ -31,7 +33,6 @@ def coverage_report(session):
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def lint(session):
-    session.run("python", "-m", "pip", "install", "-U", "pip")
     session.install(".", "-r", LINT_DEPENDENCIES)
     session.run("ruff", "format", "src", "--check")
     session.run("ruff", "check", ".")
@@ -40,6 +41,5 @@ def lint(session):
 
 @nox.session(python=PYTHON_DEFAULT_VERSION)
 def docs(session):
-    session.run("python", "-m", "pip", "install", "-U", "pip")
     session.install(".", "-r", DOC_DEPENDENCIES)
     session.run("mkdocs", "build", "--clean", "--strict")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,3 +122,6 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = "noxfile"
 disallow_untyped_decorators = false
+
+[tool.uv]
+python-downloads = "never"


### PR DESCRIPTION
Uses uv backend for nox, will fallback to virtualenv if uv not present.
Set python-downloads to never to prevent uv from downloading python even when it's installed.