### PR TITLE
Fix uv crash issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.26.1"]
 build-backend = "hatchling.build"
 
 [project]

--- a/src/piplexed/utils.py
+++ b/src/piplexed/utils.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 import warnings
+from os import getenv
+
+from rich.console import Console
+from rich.panel import Panel
+
+TERMINAL_WIDTH = getenv("TERMINAL_WIDTH")
 
 
 def future_deprecation_warning(*, reason: str, replacement: str | None, deprecation_version: str) -> None:
@@ -24,3 +30,21 @@ def future_deprecation_warning(*, reason: str, replacement: str | None, deprecat
     message = ". ".join(message_parts)
 
     warnings.warn(message.rstrip(), stacklevel=2, category=FutureWarning)
+
+
+def _get_rich_console(stderr: bool = False) -> Console:  # noqa: FBT001, FBT002
+    return Console(
+        color_system="auto",
+        width=int(TERMINAL_WIDTH) if TERMINAL_WIDTH else None,
+        stderr=stderr,
+    )
+
+
+def rich_format_error(msg: str) -> None:
+    console = _get_rich_console(stderr=True)
+    console.print(Panel(msg, border_style="red", title="Error", title_align="left", width=70))
+
+
+def rich_format_info(msg: str) -> None:
+    console = _get_rich_console()
+    console.print(Panel(msg, border_style="orange1", title="[blue]Info[/blue]", title_align="left", width=70))

--- a/src/piplexed/venvs/pipx_venvs.py
+++ b/src/piplexed/venvs/pipx_venvs.py
@@ -43,7 +43,6 @@ def get_local_venv() -> Path | None:
     return None
 
 
-# PIPX_HOME = Path(os.environ.get("PIPX_HOME", DEFAULT_PIPX_HOME)).resolve()
 PIPX_LOCAL_VENVS: Path | None = get_local_venv()
 
 
@@ -52,10 +51,9 @@ def is_metadata_version_valid(metadata_version: str, pipx_metadata_vsn: list[str
 
 
 def installed_pipx_tools(venv_dir: Path | None = PIPX_LOCAL_VENVS) -> list[PackageInfo]:
-    venvs = []
+    venvs: list[PackageInfo] = []
     if venv_dir is None or not venv_dir.exists():
-        msg = "Unable to find pipx venv installation location"
-        raise FileNotFoundError(msg)
+        return venvs
     for env in venv_dir.iterdir():
         for item in env.iterdir():
             if item.name == "pipx_metadata.json":  # pragma: no branch

--- a/src/piplexed/venvs/uv_venvs.py
+++ b/src/piplexed/venvs/uv_venvs.py
@@ -4,7 +4,6 @@ import platform
 import shutil
 import subprocess
 from pathlib import Path
-from typing import cast
 
 from packaging.utils import canonicalize_name
 from packaging.version import Version
@@ -13,25 +12,27 @@ from piplexed.venvs import PackageInfo
 from piplexed.venvs import ToolType
 
 
-def find_uv_tool_dir() -> str:
+def find_uv() -> tuple[bool, str]:
     uv_path = shutil.which("uv")
-    uv_path = cast(str, uv_path)
-    try:
-        ret = subprocess.run([uv_path, "tool", "dir"], check=False, text=True, capture_output=True)  # noqa: S603
-    except FileNotFoundError as e:
-        msg = "No UV tool directory found..."
-        raise FileNotFoundError(msg) from e
+    return uv_path is not None, uv_path or "uv"
+
+
+def find_uv_tool_dir(uv_path: str) -> str | None:
+    # uv tool dir will return a tool directory even if one does not exist
+    ret = subprocess.run([uv_path, "tool", "dir"], check=False, text=True, capture_output=True)  # noqa: S603
 
     if ret.returncode == 0:
-        return ret.stdout.strip()
-    else:
-        msg = "No UV tool directory found..."
-        raise FileNotFoundError(msg)
+        tool_dir = ret.stdout.strip()
+        return tool_dir if Path(tool_dir).exists() else None
+
+    return None
 
 
-uv_tool_dir = find_uv_tool_dir()
+HAS_UV, UV_PATH = find_uv()
 
-UV_VENV_DIR = Path(uv_tool_dir) if uv_tool_dir is not None else None
+# If we can't find uv then there is no tool directory
+UV_TOOL_DIR = find_uv_tool_dir(UV_PATH) if HAS_UV else None
+UV_VENV_DIR = Path(UV_TOOL_DIR) if UV_TOOL_DIR is not None else None
 OS_SYSTEM = platform.system()
 
 
@@ -50,7 +51,7 @@ def uv_tool_version(tool_venv_dir: Path, op_sys: str) -> str:
     return ret.stdout.strip()
 
 
-def installed_uv_tools(tool_dir: Path = UV_VENV_DIR, op_sys: str = OS_SYSTEM) -> list[PackageInfo]:
+def installed_uv_tools(tool_dir: Path | None = UV_VENV_DIR, op_sys: str = OS_SYSTEM) -> list[PackageInfo]:
     def run_subprocess(cmd: str) -> str:
         try:
             result = subprocess.run([python_path, "-c", cmd], capture_output=True, text=True, check=True)  # noqa: S603
@@ -58,7 +59,11 @@ def installed_uv_tools(tool_dir: Path = UV_VENV_DIR, op_sys: str = OS_SYSTEM) ->
         except subprocess.CalledProcessError as e:
             return f"Error: {e.stderr.strip()}"
 
-    uv_packages = []
+    uv_packages: list[PackageInfo] = []
+
+    if tool_dir is None:
+        return uv_packages
+
     for env in tool_dir.iterdir():
         if not env.name.startswith("."):
             python_path = get_python_path(env, op_sys)

--- a/tests/test_pipx_venvs.py
+++ b/tests/test_pipx_venvs.py
@@ -9,8 +9,8 @@ from unittest.mock import patch
 import pytest
 from packaging.version import Version
 
+from piplexed.venvs import PackageInfo
 from piplexed.venvs.pipx_venvs import PIPX_METADATA_VERSIONS
-from piplexed.venvs.pipx_venvs import PackageInfo
 from piplexed.venvs.pipx_venvs import get_local_venv
 from piplexed.venvs.pipx_venvs import installed_pipx_tools
 from piplexed.venvs.pipx_venvs import is_metadata_version_valid
@@ -136,18 +136,12 @@ def test_multiple_json_files_in_venv(venv_dir_test_setup):
 
 
 def test_venv_dir_is_none():
-    with pytest.raises(FileNotFoundError) as execinfo:
-        installed_pipx_tools(venv_dir=None)
-
-    assert str(execinfo.value) == "Unable to find pipx venv installation location"
+    assert installed_pipx_tools(venv_dir=None) == []
 
 
 def test_venv_dir_not_exists(tmp_path):
     non_existent_path = tmp_path / "joker"
-    with pytest.raises(FileNotFoundError) as execinfo:
-        installed_pipx_tools(venv_dir=non_existent_path)
-
-    assert str(execinfo.value) == "Unable to find pipx venv installation location"
+    assert installed_pipx_tools(venv_dir=non_existent_path) == []
 
 
 @pytest.fixture


### PR DESCRIPTION
Major oops a daisy with previous release, it failed to handle when either `pipx` or `uv` wasn't installed.
This PR does a number of things.
- No longer crashes/terminates program if either 'pipx' or 'uv' cannot be found.
- As UV can be used without installing tools via `uv tool`, differentiates between `uv` not being on path and a `uv tool` directory not being found.
- Provides warning/info messages to alert user to missing tools rather than terminating.