### PR TITLE
Fix list pypi detection

### DIFF
--- a/docs/Command-line-options.md
+++ b/docs/Command-line-options.md
@@ -27,7 +27,7 @@ piplexed list <OPTIONS>
 
 |**Name**|**Type**|**Descrtiption**|**Default**|
 |---|---|---|---|
-`--outdated`, `-O`|boolean|Check PyPI for newer versions of installed packages/tools. If `False` list packages/tools installed with specified tool.| `False`
+`--outdated`, `-O`|boolean|Check PyPI for newer versions of installed packages/tools (*installed tools not available on PyPI are ignored during check*). If `False` list packages/tools installed with specified tool.| `False`
 `--pre`, `-P`|boolean|include pre-releases in check for newer versions|`False`
 `--tree`, `-T`|boolean|Show results in a tree format|`False`
 `--tool`|text|Choose which tool packages werre installed with. Options are `pipx`, `uv`, `all`|`pipx`

--- a/docs/How-piplexed-works.md
+++ b/docs/How-piplexed-works.md
@@ -29,5 +29,8 @@ Because wheels are often platform specific, there is no guarantee that a suitabl
 
 **Piplexed** employs the strategy recommended in [PEP 700](https://peps.python.org/pep-0700/) to get the *latest* version, which utilises the [packaging](https://github.com/pypa/packaging) package to parse version numbers.
 
-!!! note
-    Most of this info was gleaned from looking at and researching [Bernát Gábor's](https://github.com/gaborbernat) package [pypi-changes](https://github.com/gaborbernat/pypi_changes), which also has heavily influenced this project.
+If any packages/tools have been installed that are not available on PyPI, such as local wheels or git repo, these will be ignored when checking for lastest PyPI version.
+
+/// note
+Most of this info was gleaned from looking at and researching [Bernát Gábor's](https://github.com/gaborbernat) package [pypi-changes](https://github.com/gaborbernat/pypi_changes), which also has heavily influenced this project.
+///

--- a/src/piplexed/pypi/pypi_info.py
+++ b/src/piplexed/pypi/pypi_info.py
@@ -7,6 +7,7 @@ from contextlib import ExitStack
 from packaging.version import InvalidVersion
 from packaging.version import Version
 from pypi_simple import DistributionPackage
+from pypi_simple import NoSuchProjectError
 from pypi_simple import PyPISimple
 from rich.progress import BarColumn
 from rich.progress import Progress
@@ -72,7 +73,11 @@ def find_most_recent_version_on_pypi(*, venvs: list[PackageInfo], is_prerelease:
 
         updates = []
         for future in as_completed(results):
-            result = future.result()
+            try:
+                result = future.result()
+            except NoSuchProjectError:
+                continue
+
             if result.newer_pypi_version():
                 updates.append(result)
             progress_bar.update(task, advance=1)

--- a/src/piplexed/venvs/pipx_venvs.py
+++ b/src/piplexed/venvs/pipx_venvs.py
@@ -67,8 +67,6 @@ def installed_pipx_tools(venv_dir: Path | None = PIPX_LOCAL_VENVS) -> list[Packa
                             stacklevel=2,
                             category=UserWarning,
                         )
-                    # packages installed from pypi have the same package and package_or_url
-                    # if data["main_package"]["package"] == data["main_package"]["package_or_url"]:
                     pkg_data = PackageInfo(
                         name=canonicalize_name(data["main_package"]["package"]),
                         version=Version(data["main_package"]["package_version"]),

--- a/src/piplexed/venvs/pipx_venvs.py
+++ b/src/piplexed/venvs/pipx_venvs.py
@@ -68,12 +68,12 @@ def installed_pipx_tools(venv_dir: Path | None = PIPX_LOCAL_VENVS) -> list[Packa
                             category=UserWarning,
                         )
                     # packages installed from pypi have the same package and package_or_url
-                    if data["main_package"]["package"] == data["main_package"]["package_or_url"]:
-                        pkg_data = PackageInfo(
-                            name=canonicalize_name(data["main_package"]["package"]),
-                            version=Version(data["main_package"]["package_version"]),
-                            python=data["python_version"].split()[-1],
-                        )
-                        venvs.append(pkg_data)
+                    # if data["main_package"]["package"] == data["main_package"]["package_or_url"]:
+                    pkg_data = PackageInfo(
+                        name=canonicalize_name(data["main_package"]["package"]),
+                        version=Version(data["main_package"]["package_version"]),
+                        python=data["python_version"].split()[-1],
+                    )
+                    venvs.append(pkg_data)
 
     return venvs

--- a/tests/test_pipx_venvs.py
+++ b/tests/test_pipx_venvs.py
@@ -118,7 +118,10 @@ def test_pipx_metadata(venv_dir_test_setup, pipx_metadata_version):
         pipx_metadata = mock_metadata(metadata_version=pipx_metadata_version, pypi_package=False)
         json.dump(pipx_metadata, f)
 
-    assert installed_pipx_tools(venv_dir_test_setup) == expected
+    results = installed_pipx_tools(venv_dir_test_setup)
+    assert expected[0] in results
+    assert expected[1] in results
+    assert len(results) == len(expected)
 
 
 def test_multiple_json_files_in_venv(venv_dir_test_setup):

--- a/tests/test_pipx_venvs.py
+++ b/tests/test_pipx_venvs.py
@@ -105,7 +105,10 @@ def test_pipx_metadata(venv_dir_test_setup, pipx_metadata_version):
     pypi_json = venv_dir_test_setup / "pypi_package" / "pipx_metadata.json"
     local_json = venv_dir_test_setup / "local_package" / "pipx_metadata.json"
 
-    expected = [PackageInfo(name="testy-mctestface", version=Version("23.1.0"), python="3.11.2")]
+    expected = [
+        PackageInfo(name="local-package", version=Version("23.1.0"), python="3.11.2"),
+        PackageInfo(name="testy-mctestface", version=Version("23.1.0"), python="3.11.2"),
+    ]
 
     with open(pypi_json, "w") as f:
         pipx_metadata = mock_metadata(metadata_version=pipx_metadata_version)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] ⚡ Optimization
- [ ] ♻ Refactor
- [ ] ✅ Test
- [ ] 🤷‍♂️ Other

## Relevant issues

- Related issue #\<issue number\>
- Closes #69 

## Checklist

- [x] Ran linter to check style and type issues (`nox -s lint`)
- [x] Tests added
- [x] Documented the changes

## If you have comments or can explain your changes, please do so below

For tools installed with pipx, a metadata file is produced by pipx, which piplexed uses to determine package version and python version. There are 2 fields in this metadata file `package` and `package_or_url`, usually when a package is installed from pypi these two fields are identical. 

Piplexed used this equality check to determine if a package was installed from pypi or not, however, it turns out that if a package is installed with optional extras e.g. `package_A[extras]` then the `package` metadata field is `package_A` and `package_or_ul` is `package_A[extras]`. The idea of the check was to prevent querying of pypi with a non-pypi package, but it has some downsides.

- Tools installed from somewhere other than PyPI or with optional extras do not show when `piplexed list` is run
- Tools installed with optional extras never get checked for newer PyPI version.

This PR removes the early equality check and handles the error of a querying pypi with a non-pypi package.
